### PR TITLE
Patch to README for local setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Save and close the file. Reactivate your development environment so `postactivat
 
 Hurray! Your local copy of Census Reporter will be hitting our production data sources, so you should be able to search and browse just like you would on the live website. If you'd like to go a step further, you can <a href="https://github.com/censusreporter/census-api">run the API locally</a>, and even <a href="http://censusreporter.tumblr.com/post/73727555158/easier-access-to-acs-data">load the entire Postgres database locally</a>, as well. But if you're primarily interested in adding features to the Census Reporter website or just seeing how it works, the instructions above should get you going.
 
+** Note ** for people who wish to develop for Census Reporter
+
+If you are running the django server from within the vagrant box, provide the localhost explicitly 
+
+    >> python manage.py runserver 0.0.0.0:8000
+
+The application can now be accessed via localhost:8000 on your browser
+
 Getting data from our API (the basics)
 ======================================
 


### PR DESCRIPTION
Patch provides extra info for developers running django server from vagrant box. The vagrant install script tries to establish this info but can be easily ignored by the dev, leading to slight confusion
